### PR TITLE
There is a case that mapping only has 2 members

### DIFF
--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -14,6 +14,9 @@ function FlattenSourceMap(map) {
   });
 
   originalMap._mappings.forEach(function(m){
+    if (mapping.length != 5) {
+      return;
+    }
     var mapping = {
       source: m[2],
       original: {

--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -14,7 +14,7 @@ function FlattenSourceMap(map) {
   });
 
   originalMap._mappings.forEach(function(m){
-    if (mapping.length != 5) {
+    if (mapping.length < 5) {
       return;
     }
     var mapping = {

--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -14,7 +14,7 @@ function FlattenSourceMap(map) {
   });
 
   originalMap._mappings.forEach(function(m){
-    if (mapping.length < 5) {
+    if (m.length < 5) {
       return;
     }
     var mapping = {


### PR DESCRIPTION
There is a case that mapping only has 2 members, which means that source code has no mapping. This is happened in source map generated by babel.
